### PR TITLE
Ensure overided video/log output directory maps to correct path inside selenoid container.

### DIFF
--- a/tasks/selenoid.yml
+++ b/tasks/selenoid.yml
@@ -12,8 +12,11 @@
     volumes:
       - '/var/run/docker.sock:/var/run/docker.sock'
       - '{{ selenoid_config_dir }}:/root'
+      - '{{ selenoid_config_dir }}/video:/opt/selenoid/video/'
+      - '{{ selenoid_config_dir }}/logs:/opt/selenoid/logs/'
     env:
       OVERRIDE_HOME: '{{ selenoid_config_dir }}'
+      OVERRIDE_VIDEO_OUTPUT_DIR: '{{ selenoid_config_dir }}/video'
     command: >
       selenoid start
         --last-versions 3

--- a/templates/selenoid.service.j2
+++ b/templates/selenoid.service.j2
@@ -6,7 +6,7 @@ Environment="DOCKER_API_VERSION=1.38"
 Type=simple
 User=selenoid
 GuessMainPID=true
-ExecStart={{ selenoid_config_dir }}/selenoid -conf {{ selenoid_config_dir }}/config/browsers.json -video-output-dir {{ selenoid_config_dir }}/video -limit {{ concurrent_session_count }}
+ExecStart={{ selenoid_config_dir }}/selenoid -conf {{ selenoid_config_dir }}/config/browsers.json -video-output-dir /opt/selenoid/video -log-output-dir /opt/selenoid/logs -limit {{ concurrent_session_count }}
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStop=/bin/kill -15 $MAINPID
 Restart=always


### PR DESCRIPTION

# Pull Request Template

## Description

Currently, when tests are run, video recording can not be accesses at http://selenoid-host.example.com:4444/video/<filename>.mp4, also logs can not be accessed at http://selenoid-host.example.com:4444/logs/<filename>.mp4 as video & log directories are not mapped on local host machine.
Updated code to ensure mapping between local host directory & default video/log directory location inside container

Fixes # (issue)

## Type of change

Please delete options that are not relevant.


## Reviews

Please identify developer to review this change

- [x] @developer

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass with my changes
